### PR TITLE
support using Near selector on a time axis

### DIFF
--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -41,7 +41,7 @@ Base.show(io::IO, s::Near) = print(io, "Near(",s.val,")")
 Base.show(io::IO, ::MIME"text/plain", s::Near{T}) where {T} =
     print(io, "Near(",s.val,") ::Selector{",T,"}")
 
-findindex(sel::Near, range::AbstractArray) = argmin(map(x -> abs2(x-sel.val), range))
+findindex(sel::Near, range::AbstractArray) = argmin(map(x -> abs(x-sel.val), range))
 
 _index_key_doc = """
     Index[i]

--- a/test/_packages.jl
+++ b/test/_packages.jl
@@ -65,6 +65,10 @@ end
     @test D(w9) == D[week=9]
     # But steps of Year(1) don't work, https://github.com/JuliaLang/julia/issues/35203
 
+    @test D(==(Date(2020, 1, 8))) == D[:, 2:2]
+    @test D(Near(Date(2020, 1, 10))) == D(Date(2020, 1, 8)) == D[:, 2]
+    @test D(Interval(Date(2020, 1, 8), Date(2020, 1, 22))) == D[:, 2:4]
+
 end
 @testset "inverted" begin
 


### PR DESCRIPTION
This avoids this error: `MethodError: no method matching abs2(::Millisecond)`