### PR TITLE
Support for FFT

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ license = "MIT"
 version = "0.1.2"
 
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 LazyStack = "1fad7336-0346-5a1a-a56f-a06ba010965b"
@@ -14,6 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+AbstractFFTs = "0.5"
 BenchmarkTools = "0.5"
 IntervalSets = "0.3, 0.4, 0.5"
 InvertedIndices = "1.0"
@@ -26,8 +28,10 @@ julia = "1"
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UniqueVectors = "2fbcfb34-fd0c-5fbb-b5d7-e826d8f5b0a9"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["BenchmarkTools", "Dates", "Test", "UniqueVectors"]
+test = ["BenchmarkTools", "Dates", "FFTW", "Test", "UniqueVectors", "Unitful"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ operations on arrays, including broadcasting, `map`, comprehensions, `sum` etc.
 It works closely with [NamedDims.jl](https://github.com/invenia/NamedDims.jl), another wrapper 
 which attaches names to dimensions. These names are a tuple of symbols, like those of 
 a `NamedTuple`. They can be used for specifying which dimensions to sum over, etc.
-The function `wrapdims` constructs a nested pair of these wrappers, for example: 
+A nested pair of these wrappers can be made as follows:
 
 ```julia
 using AxisKeys
@@ -27,7 +27,7 @@ A = KeyedArray(data; channel=[:left, :right], time=range(13, step=2.5, length=10
 ### Selections
 
 Indexing still works directly on the underlying array, 
-and keyword indexing works exactly as for a `NamedDimsArray`.
+and keyword indexing (of a nested pair) works exactly as for a `NamedDimsArray`.
 But in addition, it is possible to pick out elements based on the keys,
 which for clarity we will call lookup. This is written with round brackets:
 
@@ -139,6 +139,10 @@ while `A.keys isa Tuple` for matrices & higher. But `axiskeys(A)` always returns
 
 * Named tuples can be converted to and from keyed vectors,
   with `collect(keys(nt)) == Symbol.(axiskeys(V),1)`
+
+* [FFTW](https://github.com/JuliaMath/FFTW.jl)`.fft` transforms the keys; 
+  if these are times such as [Unitful](https://github.com/PainterQubits/Unitful.jl)`.s` 
+  then the results are fequency labels.
 
 * [LazyStack](https://github.com/mcabbott/LazyStack.jl)`.stack` understands names and keys.
   Stacks of named tuples like `stack((a=i, b=i^2) for i=1:5)` create a matrix with `[:a, :b]`.

--- a/src/AxisKeys.jl
+++ b/src/AxisKeys.jl
@@ -29,4 +29,6 @@ include("tables.jl") # Tables.jl
 
 include("stack.jl") # LazyStack.jl
 
+include("fft.jl") # AbstractFFTs.jl
+
 end

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -9,32 +9,74 @@ because extracting the dimensions from those is tricky
 
 using AbstractFFTs
 
-for fun in [:fft, :ifft, :bfft, :rfft,]
-    freq = fun == :rfft ? :rfftfreq : :fftfreq
+for fun in [:fft, :ifft, :bfft, :rfft]
     @eval function AbstractFFTs.$fun(A::Union{KeyedArray,NdaKa}, dims = ntuple(+,ndims(A)))
         numerical_dims = hasnames(A) ? NamedDims.dim(dimnames(A), dims) : dims
-        data = AbstractFFTs.$fun(keyless(A), numerical_dims)
-        keys = ntuple(ndims(A)) do d
-            k = axiskeys(A,d)
-            d in numerical_dims || return k
-            k isa AbstractRange{<:Number} || k isa AbstractFFTs.Frequencies || return k
-            # eltype(k) <: Integer && return k
-            AbstractFFTs.$freq(length(k), inv(step(k)))
-        end
+        data = $fun(keyless(A), numerical_dims)
+        keys = fft_keys($fun, A, numerical_dims, data)
         KeyedArray(data, keys)
     end
+end
+
+function AbstractFFTs.irfft(A::Union{KeyedArray,NdaKa}, len::Integer, dims = ntuple(+,ndims(A)))
+    numerical_dims = hasnames(A) ? NamedDims.dim(dimnames(A), dims) : dims
+    data = irfft(keyless(A), len, numerical_dims)
+    keys = fft_keys(irfft, A, numerical_dims, data)
+    KeyedArray(data, keys)
 end
 
 for shift in [:fftshift, :ifftshift]
     @eval function AbstractFFTs.$shift(A::Union{KeyedArray,NdaKa}, dims = ntuple(+,ndims(A)))
         numerical_dims = hasnames(A) ? NamedDims.dim(dimnames(A), dims) : dims
-        data = AbstractFFTs.$shift(keyless(A), numerical_dims)
+        data = $shift(keyless(A), numerical_dims)
         keys = ntuple(ndims(A)) do d
             k = axiskeys(A,d)
             d in numerical_dims || return k
-            AbstractFFTs.$shift(k)
+            $shift(k)
         end
         KeyedArray(data, keys)
     end
 end
 
+# copy(fftfreq(10, 1)) isa Vector # perhaps that needs a method:
+Base.copy(x::Frequencies{<:Number}) = x
+
+fft_keys(f, A, dims, B) = ntuple(ndims(A)) do d
+        k = axiskeys(A,d)
+        d in dims || return k
+        if k isa Frequencies
+            return fft_un_freq(k)
+        elseif k isa AbstractRange{<:Number}
+            return fftfreq(length(k), inv(step(k)))
+        end
+        return k
+    end
+
+fft_keys(::typeof(rfft), A, dims, B) = ntuple(ndims(A)) do d
+        k = axiskeys(A,d)
+        d in dims || return k
+        if k isa Frequencies || k isa AbstractRange{<:Number}
+            return rfftfreq(length(k), inv(step(k)))
+        end
+        return axes(B,d)
+    end
+
+fft_keys(::typeof(irfft), A, dims, B) = ntuple(ndims(A)) do d
+        k = axiskeys(A,d)
+        d in dims || return k
+        if k isa Frequencies || k isa AbstractRange{<:Number}
+            return irfft_un_freq(k, size(B,d))
+        end
+        return axes(B,d)
+    end
+
+# This just chooses a nicer zero when inverting FFT:
+function fft_un_freq(x::Frequencies)
+    s = inv(x.multiplier * x.n)
+    range(zero(s), step = s, length = x.n)
+end
+
+function irfft_un_freq(x, len)
+    s = inv(step(x) * len)
+    range(zero(s), step = s, length = len)
+end

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -1,0 +1,40 @@
+
+#=
+Simple support for FFTs using:
+https://github.com/JuliaMath/AbstractFFTs.jl
+
+Does not (yet) cover plan_fft & friends,
+because extracting the dimensions from those is tricky
+=#
+
+using AbstractFFTs
+
+for fun in [:fft, :ifft, :bfft, :rfft,]
+    freq = fun == :rfft ? :rfftfreq : :fftfreq
+    @eval function AbstractFFTs.$fun(A::Union{KeyedArray,NdaKa}, dims = ntuple(+,ndims(A)))
+        numerical_dims = hasnames(A) ? NamedDims.dim(dimnames(A), dims) : dims
+        data = AbstractFFTs.$fun(keyless(A), numerical_dims)
+        keys = ntuple(ndims(A)) do d
+            k = axiskeys(A,d)
+            d in numerical_dims || return k
+            k isa AbstractRange{<:Number} || k isa AbstractFFTs.Frequencies || return k
+            # eltype(k) <: Integer && return k
+            AbstractFFTs.$freq(length(k), inv(step(k)))
+        end
+        KeyedArray(data, keys)
+    end
+end
+
+for shift in [:fftshift, :ifftshift]
+    @eval function AbstractFFTs.$shift(A::Union{KeyedArray,NdaKa}, dims = ntuple(+,ndims(A)))
+        numerical_dims = hasnames(A) ? NamedDims.dim(dimnames(A), dims) : dims
+        data = AbstractFFTs.$shift(keyless(A), numerical_dims)
+        keys = ntuple(ndims(A)) do d
+            k = axiskeys(A,d)
+            d in numerical_dims || return k
+            AbstractFFTs.$shift(k)
+        end
+        KeyedArray(data, keys)
+    end
+end
+

--- a/test/_packages.jl
+++ b/test/_packages.jl
@@ -1,5 +1,5 @@
 using Test, AxisKeys
-using OffsetArrays, UniqueVectors, Tables, LazyStack, Dates, InvertedIndices
+using OffsetArrays, UniqueVectors, Tables, LazyStack, Dates, InvertedIndices, FFTW
 
 @testset "offset" begin
 
@@ -81,3 +81,96 @@ end
     @test N[c=Not(2,4)] == N(c=Index[Not(2,4)])
 
 end
+@testset "FFT" begin
+
+    times = 0.1:0.1:10
+    data = rand(100) ./ 10; data[1:5:end] .= 1;
+    A = KeyedArray(data, times)
+    Atil = fft(A)
+    @test axiskeys(Atil,1)[end] == -0.1
+
+    Ashift = fftshift(Atil)
+    @test axiskeys(Ashift,1)[end] == +4.9
+
+    Ar = rfft(A) # different size, different freqencies
+    @test axiskeys(Ar,1)[end] == 5.0
+
+    A2 = ifft(ifftshift(Ashift))
+    A ≈ A2
+    @test all(mod.(axiskeys(A,1) .- axiskeys(A2,1),10) .≈ 0.1) # that's OK I think?
+
+    data2 = randn(32,2);
+    B = wrapdims(data2, time=100:10:410.0, col=[:a, :b])
+    @test_skip Btil = fftshift(fft(B, :time), :time) # result does not have names
+    Btil = fftshift(fft(B, :time), 1)
+    @test parent(Btil) ≈ fftshift(fft(data2,1),1)
+
+end
+
+
+
+
+
+
+
+#=
+using FFTW, Unitful, Plots, UnitfulRecipes
+using Unitful: s
+
+times = 0.1s:0.1s:10s
+data = rand(100) ./ 10; data[1:5:end] .= 1;
+# data = zeros(100) .* 1mV; data[1:5:end] .= 1mV; # MethodError: no method matching plan_fft(::Array{Quantity{Float64,𝐋²*𝐌*𝐈⁻¹*𝐓⁻³ ...
+
+# plot(ustrip(times), data)
+plot(times, data)
+
+fft(data)
+
+freqs = fftfreq(length(times), 1/step(times)) # better!
+
+fftfreq(freqs)
+
+# plot(ustrip(freqs) , abs2.(fft(data)))
+plot(freqs , abs2.(fft(data))) # DimensionError: Inf and 0.0 s are not dimensionally compatible.
+
+using AxisKeys, AbstractFFTs
+using AxisKeys: keyless
+
+
+kd = KeyedArray(data, times)
+
+abs.(fft(kd)) # broadcasting is collecting the keys to a vector here?
+
+fftshift(ans)
+
+data2 = rand(100,2) ./ 10; data2[1:5:end, 1] .= 1; data2[3:7:end, 2] .= 1;
+kd2 = KeyedArray(data2, (times, [:a, :b]))
+
+fftshift(fft(kd2, 1),1)
+
+
+
+
+fr = fftfreq(10, 1)
+dump(fr)
+fftshift(fr)
+typeof(ans)
+
+fr = fftfreq(10, inv(1s))
+fftshift(fr) # is a steprange, good
+
+
+
+
+using Plots, Unitful
+using Unitful: s
+
+times = 0.1s:0.1s:10s
+data = rand(100) ./ 10; data[1:5:end] .= 1;
+
+plot(ustrip(times), data)
+plot(times, data) # DimensionError: Inf and 0.1 s are not dimensionally compatible.
+# isless(::Quantity{Float64,NoDims,Unitful.FreeUnits{(),NoDims,nothing}}, ::Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}}) at /Users/me/.julia/packages/Unitful/PZjMS/src/quantities.jl:231
+
+=#
+


### PR DESCRIPTION
```julia
using AxisKeys, FFTW, Unitful
using Unitful: s

times = 0.1s:0.1s:10s
data = rand(100) ./ 10; data[1:5:end] .= 1;
A = KeyedArray(data, times)
Atil = fftshift(fft(A))

using Plots, UnitfulRecipes
plot(axiskeys(Atil,1), abs.(parent(Atil)))
```
Todo:
- [x] turn `Frequencies` back into a `StepRange`
- [x] `abs.(fft(A))` has a `Vector` of keys, why?
- [ ] `plan_fft` perhaps?