### PR TITLE
Add support for KeyedArrays as a Tables sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ while `A.keys isa Tuple` for matrices & higher. But `axiskeys(A)` always returns
 * Named tuples can be converted to and from keyed vectors,
   with `collect(keys(nt)) == Symbol.(axiskeys(V),1)`
 
+* The [Tables.jl](https://github.com/JuliaData/Tables.jl) interface is supported,
+  with `wrapdims(df, :val, :x, :y)` creating a matrix from 3 columns.
+
 * [FFTW](https://github.com/JuliaMath/FFTW.jl)`.fft` transforms the keys; 
   if these are times such as [Unitful](https://github.com/PainterQubits/Unitful.jl)`.s` 
   then the results are fequency labels. ([PR#15](https://github.com/mcabbott/AxisKeys.jl/pull/15).)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -115,3 +115,65 @@ end
 
 #     end
 # end
+
+"""
+    populate!(A, table, value)
+
+Populate A with the contents of the `value` column in a provided table.
+The provided table contain columns corresponding to the keys in A and support row iteration.
+"""
+function populate!(A, table, value::Symbol)
+    cols = [value, dimnames(A)...]
+    for r in Tables.rows(table)
+        setkey!(A, (Tables.getcolumn(r, c) for c in cols)...)
+    end
+    return A
+end
+
+"""
+    KeyedArray(table, value, keys...; default=undef)
+    NamedDimsArray(table, value, keys...; default=undef)
+
+Construct a KeyedArray/NamedDimsArray from a `table` supporting column and row.
+`keys` columns are extracted as is, without sorting, and are assumed to uniquely identify
+each `value`. The `default` value is used in cases where no value is identified for a given
+keypair.
+"""
+function KeyedArray(table, value::Symbol, keys::Symbol...; kwargs...)
+   return _construct_from_table(KeyedArray, table, value, keys...; kwargs...)
+end
+
+function NamedDimsArray(table, value::Symbol, keys::Symbol...; kwargs...)
+   return _construct_from_table(NamedDimsArray, table, value, keys...; kwargs...)
+end
+
+
+# Internal function for constructing the KeyedArray or NamedDimsArray.
+# This code doesn't care which type we produce so we just pass that along.
+function _construct_from_table(
+    T::Type, table, value::Symbol, keys::Symbol...;
+    default=undef, issorted=false
+)
+    # get columns of the input table source
+    cols = Tables.columns(table)
+
+    # Extract key columns
+    kw = Tuple(k => unique(Tables.getcolumn(cols, k)) for k in keys)
+
+    # Extract data/value column
+    vals = Tables.getcolumn(cols, value)
+
+    # Initialize the KeyedArray
+    sz = length.(last.(kw))
+
+    A = if default === undef
+        data = similar(vals, sz)
+    else
+        data = similar(vals, Union{eltype(vals), typeof(default)}, sz)
+        fill!(data, default)
+    end
+
+    A = T(data; kw...)
+    populate!(A, table, value)
+    return A
+end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -149,29 +149,55 @@ function populate!(A, table, value::Symbol; force=false)
 end
 
 """
-    wrapdims(table, value, keys...; default=undef, sort=false, force=false) -> KeyedArray
-    wrapdims(T, table, value, keys...; default=undef, sort=false, force=false) -> T
+    wrapdims(table, value, names...; default=undef, sort=false, force=false)
 
-Construct a `KeyedArray`/`NamedDimsArray` (specified by type `T`) from a `table` matching
-the [Tables.jl](https://github.com/JuliaData/Tables.jl) API. The `table` should support both
-`Tables.columns` and `Tables.rows`. The `default` value is used in cases where no
-value is identified for a given keypair. If the `keys` columns do not uniquely identify
-rows in the table then an `ArgumentError` is throw. If `force` is true then the duplicate
-(non-unique) entries will be overwritten.
+Construct `KeyedArray(NamedDimsArray(A,names),keys)` from a `table` matching
+the [Tables.jl](https://github.com/JuliaData/Tables.jl) API.
+(It must support both `Tables.columns` and `Tables.rows`.)
+
+The contents of the array is taken from the column `value::Symbol` of the table.
+Each symbol in `names` specifies a column whose unique entries
+become the keys along a dimenension of the array.
+
+If there is no row in the table matching a possible set of keys,
+then this element of the array is undefined, unless you provide the `default` keyword.
+If several rows share the same set of keys, then by default an `ArgumentError` is thrown.
+Keyword `force=true` will instead cause these non-unique entries to be overwritten.
+
+Setting `AxisKeys.nameouter() = false` will reverse the order of wrappers produced.
 """
-function wrapdims(table, value::Symbol, keys::Symbol...; kwargs...)
-    wrapdims(KeyedArray, table, value, keys...; kwargs...)
+function wrapdims(table, value::Symbol, names::Symbol...; kw...)
+    if nameouter() == false
+        _wrap_table(KeyedArray, identity, table, value, names...; kw...)
+    else
+        _wrap_table(NamedDimsArray, identity, table, value, names...; kw...)
+    end
 end
 
-function wrapdims(T::Type, table, value::Symbol, keys::Symbol...; default=undef, sort::Bool=false, kwargs...)
+"""
+    wrapdims(df, UniqueVector, :val, :x, :y)
+
+Converts at Tables.jl table to a `KeyedArray` + `NamedDimsArray` pair,
+using column `:val` for values, and columns `:x, :y` for names & keys.
+Optional 2nd argument applies this type to all the key-vectors.
+"""
+function wrapdims(table, KT::Type, value::Symbol, names::Symbol...; kw...)
+    if nameouter() == false
+        _wrap_table(KeyedArray, KT, table, value, names...; kw...)
+    else
+        _wrap_table(NamedDimsArray, KT, table, value, names...; kw...)
+    end
+end
+
+function _wrap_table(AT::Type, KT, table, value::Symbol, names::Symbol...; default=undef, sort::Bool=false, kwargs...)
     # get columns of the input table source
     cols = Tables.columns(table)
 
     # Extract key columns
-    pairs = map(keys) do k
+    pairs = map(names) do k
         col = unique(Tables.getcolumn(cols, k))
         sort && Base.sort!(col)
-        return k => col
+        return k => KT(col)
     end
 
     # Extract data/value column
@@ -179,15 +205,14 @@ function wrapdims(T::Type, table, value::Symbol, keys::Symbol...; default=undef,
 
     # Initialize the KeyedArray
     sz = length.(last.(pairs))
-
-    A = if default === undef
+    if default === undef
         data = similar(vals, sz)
     else
         data = similar(vals, Union{eltype(vals), typeof(default)}, sz)
         fill!(data, default)
     end
+    A = AT(data; pairs...)
 
-    A = T(data; pairs...)
     populate!(A, table, value; kwargs...)
     return A
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,13 +9,13 @@ using Statistics, OffsetArrays, Tables, UniqueVectors, LazyStack
         AxisKeys.nameouter() = false
     end
 
-    # include("_basic.jl")
+    include("_basic.jl")
 
     include("_functions.jl")
 
-    # include("_fast.jl")
+    include("_fast.jl")
 
-    # include("_packages.jl")
+    include("_packages.jl")
 
 end
 @testset "fast findfirst & findall" begin


### PR DESCRIPTION
We have two main use cases for this:

1. Wanting to construct KeyedArrays from adhoc DataFrames
2. Wanting to populate a pre-allocated Array from LibPQ.jl results. For example, we know how many timestamps, locations, ids, etc we expect to get back from our DB. 

We've been doing this internally for AxisArrays for a while, but never got around to open sourcing it.