### PR TITLE
Add a selectdim wrapper

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -116,6 +116,10 @@ function Base.mapslices(f, A::KeyedArray; dims)
     KeyedArray(data, new_keys)#, copy(A.meta))
 end
 
+function Base.selectdim(A::KeyedArray, s::Symbol, i)
+    return selectdim(A, NamedDims.dim(dimnames(A), s), i)
+end
+
 for (T, S) in [(:KeyedVecOrMat, :KeyedVecOrMat), # KeyedArray gives ambiguities
     (:KeyedVecOrMat, :AbstractVecOrMat), (:AbstractVecOrMat, :KeyedVecOrMat),
     (:NdaKaVoM, :NdaKaVoM),

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -116,9 +116,7 @@ function Base.mapslices(f, A::KeyedArray; dims)
     KeyedArray(data, new_keys)#, copy(A.meta))
 end
 
-function Base.selectdim(A::KeyedArray, s::Symbol, i)
-    return selectdim(A, NamedDims.dim(dimnames(A), s), i)
-end
+Base.selectdim(A::KeyedArray, s::Symbol, i) = selectdim(A, NamedDims.dim(A, s), i)
 
 for (T, S) in [(:KeyedVecOrMat, :KeyedVecOrMat), # KeyedArray gives ambiguities
     (:KeyedVecOrMat, :AbstractVecOrMat), (:AbstractVecOrMat, :KeyedVecOrMat),

--- a/test/_functions.jl
+++ b/test/_functions.jl
@@ -46,6 +46,8 @@ A3 = wrapdims(rand(Int8, 3,4,2), r='a':'c', c=2:5, p=[10.0, 20.0])
         @test axiskeys(first(eachslice(M, dims=:r))) === (2:5,)
     end
 
+    @test axiskeys(selectdim(M, :r, [true, false, true])) == (['a', 'c'], 2:5)
+
     # mapslices
     @test axiskeys(mapslices(identity, M, dims=1)) === (Base.OneTo(3), 2:5)
     @test axiskeys(mapslices(sum, M, dims=1)) === (Base.OneTo(1), 2:5)


### PR DESCRIPTION
Just extracts the numeric dim with the base `selectdim` call. Same as what NamedDims.jl does [here](https://github.com/invenia/NamedDims.jl/blob/942bb283c62dd64c0ca484bda19c1bb832f268fa/src/functions_dims.jl#L17).