### PR TITLE
make mapreduce pass on kwargs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -36,7 +36,7 @@ tuple_flatten(x::Tuple, ys::Tuple...) = (x..., tuple_flatten(ys...)...)
 tuple_flatten() = ()
 
 function Base.mapreduce(f, op, A::KeyedArray; dims=:, kwargs...) # sum, prod, etc
-    dims === Colon() && return mapreduce(f, op, parent(A))
+    dims === Colon() && return mapreduce(f, op, parent(A); kwargs...)
     numerical_dims = NamedDims.dim(A, dims)
     data = mapreduce(f, op, parent(A); dims=numerical_dims, kwargs...)
     new_keys = ntuple(d -> d in numerical_dims ? Base.OneTo(1) : axiskeys(A,d), ndims(A))

--- a/test/_functions.jl
+++ b/test/_functions.jl
@@ -60,8 +60,12 @@ A3 = wrapdims(rand(Int8, 3,4,2), r='a':'c', c=2:5, p=[10.0, 20.0])
         @test reshape(M, (4,3)) isa Array
         @test reshape(M, (2,:)) isa Array
     end
-
 end
+@testset "Regression test against https://github.com/mcabbott/AxisKeys.jl/issues/43" begin
+    z = KeyedArray(zeros(3); foo=[:a, :b, :c])
+    @test mapreduce(identity, +, z; init=10) == 10
+end
+
 @testset "sort" begin
 
     @test sort(V)(20) == V(20)


### PR DESCRIPTION
Fixed #43 
I note that later in the file for `mean`, `std`, `var` the same thing is true, but idk if it matters in those cases,
and I don't have easy MWE.
I can make follow ups for these, but I would like to get this one merged and released ASAP as it is breaking my code