### PR TITLE
Support rekeying a KeyedArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/AxisKeys.jl
+++ b/src/AxisKeys.jl
@@ -6,7 +6,7 @@ export KeyedArray, axiskeys
 include("lookup.jl")
 
 include("names.jl")
-export named_axiskeys
+export named_axiskeys, rekey
 export NamedDimsArray, dimnames, rename  # Reexport key NamedDimsArrays things
 
 include("wrap.jl")

--- a/src/names.jl
+++ b/src/names.jl
@@ -179,11 +179,9 @@ end
     rekey(A, (1:10, [:a, :b]))
     rekey(A, 2 => [:a, :b])
     rekey(A, :y => [:a, :b])
-    rekey(A, :y => q => [:a, :b])
 
-Rekey a KeyedArray via `Tuple`s, `dim => newkey`. If `A` also has named dimensions then you
-can also pass `dimname => newkey`, or even `oldname => newname => newkey` to both `rename`
-and `rekey` the specified dimension.
+Rekey a KeyedArray via `Tuple`s or `Pair`s, `dim => newkey`. If `A` also has named
+dimensions then you can also pass `dimname => newkey`.
 """
 rekey(A::Union{KeyedArray, NdaKa}, k2::Tuple) = KeyedArray(keyless(A), k2)
 function rekey(A::Union{KeyedArray, NdaKa}, k2::Pair{<:Integer, <:AbstractVector}...)
@@ -198,12 +196,4 @@ end
 function rekey(A::Union{KaNda, NdaKa}, k2::Pair{Symbol, <:AbstractVector}...)
     pairs = map(p -> NamedDims.dim(A, p[1]) => p[2], k2)
     return rekey(A, pairs...)
-end
-
-function rekey(A::Union{KaNda, NdaKa}, k2::Pair{Symbol, <:Pair}...)
-    # Extract rekey pairs from k2
-    rekey_pairs = last.(k2)
-    # Extract the current dimname and desired dimname into pairs
-    rename_pairs = Pair.(first.(k2), first.(rekey_pairs))
-    return rekey(rename(A, rename_pairs...), rekey_pairs...)
 end

--- a/test/_basic.jl
+++ b/test/_basic.jl
@@ -180,8 +180,6 @@ end
         @test axiskeys(rekey(N, 2 => 1:4)) == (['a', 'b', 'c'], 1:4)
         # Rekey with dimname => axiskey pair
         @test axiskeys(rekey(N, :iter => 1:4)) == (['a', 'b', 'c'], 1:4)
-        # Rekey and rename
-        @test named_axiskeys(rekey(N, :obs => :label => [:x, :y, :z])) == (label=[:x, :y, :z], iter=10:10:40)
     end
 
     @testset "named_axiskeys" begin

--- a/test/_basic.jl
+++ b/test/_basic.jl
@@ -170,6 +170,18 @@ end
 
         @test_throws Exception N(obs=55)  # ideally ArgumentError
         @test_throws Exception N(obs='z') # ideally BoundsError
+
+        new_obs = [:x, :y, :z]
+        new_iter = 1:4
+
+        # Rekey with Tuple
+        @test axiskeys(rekey(N, ([:x, :y, :z], 1:4))) == ([:x, :y, :z], 1:4)
+        # Rekey with dim => axiskey pair
+        @test axiskeys(rekey(N, 2 => 1:4)) == (['a', 'b', 'c'], 1:4)
+        # Rekey with dimname => axiskey pair
+        @test axiskeys(rekey(N, :iter => 1:4)) == (['a', 'b', 'c'], 1:4)
+        # Rekey and rename
+        @test named_axiskeys(rekey(N, :obs => :label => [:x, :y, :z])) == (label=[:x, :y, :z], iter=10:10:40)
     end
 
     @testset "named_axiskeys" begin


### PR DESCRIPTION
I decided to go with pairs vs kwargs because:

1. I wanted to support unnamed dims
2. The nested pair syntax of `oldname => newname => newvalues` seemed more intuitive than mixing pairs and kwargs.

Closes #60 