### PR TITLE
indexing a range with a range produces another range

### DIFF
--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -95,6 +95,8 @@ findindex(i::Int, r::Base.OneTo{Int}) = 1 <= i <= r.stop ? i : nothing
 
 findindex(i::Int, r::AbstractUnitRange) = first(r) <= i <= last(r) ? 1+Int(i - first(r)) : nothing
 
+findindex(i::AbstractUnitRange{T}, r::AbstractUnitRange{T}) where {T} = findall(∈(i), r)
+
 # Faster than Base.findall(==(i), 1:10) etc,
 # but returning a range not an Array:
 

--- a/test/_findrange.jl
+++ b/test/_findrange.jl
@@ -9,6 +9,10 @@ if VERSION >= v"1.2" # <(3) doesn't exist on 1.1, but Base.Fix2 is fine
 @testset "unit ranges" begin
 
     for r in (Base.OneTo(5), 2:5)
+        x = 2:4
+        @test r[AxisKeys.findindex(x, r)] == x
+        @test @inferred(AxisKeys.findindex(x, r)) isa AbstractUnitRange
+
         for x in -2:7
 
             @test AxisKeys.findindex(x, r) == findfirst(==(x), collect(r))


### PR DESCRIPTION
Before this change findindex(2:4, 2:5) returned a materialized array.