### PR TITLE
fix warning on julia 1.7

### DIFF
--- a/src/names.jl
+++ b/src/names.jl
@@ -100,7 +100,7 @@ end
 @inline @propagate_inbounds function getkey(A; kw...)
     list = dimnames(A)
     issubset(keys(kw), list) || error("some keywords not in list of names!")
-    args = map(s -> Base.sym_in(s, kw.itr) ? getfield(values(kw), s) : Colon(), list)
+    args = map(s -> Base.sym_in(s, keys(kw)) ? getfield(values(kw), s) : Colon(), list)
     A(args...)
 end
 

--- a/src/push.jl
+++ b/src/push.jl
@@ -89,7 +89,7 @@ append!!(r::AbstractVector, s::AbstractVector) = (extend_by!!(r, length(s)); vca
 This pushes `val` into `A.data`, and pushes `key` to `axiskeys(A,1)`.
 Both of these must be legal operations, e.g. `A = wrapdims([1], ["a"]); push!(A, b=2)`.
 """
-Base.push!(A::KeyedArray; kw...) = push!(A, map(Pair, keys(kw), values(kw.data))...)
+Base.push!(A::KeyedArray; kw...) = push!(A, map(Pair, keys(kw), values(values(kw)))...)
 
 function Base.push!(A::KeyedArray, pairs::Pair...)
     axiskeys(A,1) isa AbstractRange && error("can't use push!(A, key => val) when axiskeys(A,1) isa AbstractRange")

--- a/src/show.jl
+++ b/src/show.jl
@@ -137,7 +137,7 @@ struct ShowWith{T,NT} <: AbstractString
     hide::Bool
     nt::NT
     ShowWith(val; hide::Bool=false, kw...) =
-        new{typeof(val),typeof(kw.data)}(val, hide, kw.data)
+        new{typeof(val),typeof(values(kw))}(val, hide, values(kw))
 end
 function Base.show(io::IO, x::ShowWith; kw...)
     # ioc = IOContext(io, :compact => true) # using this really breaks spacing!


### PR DESCRIPTION
    Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr

Comes from https://github.com/JuliaLang/julia/pull/39448
