### PR TITLE
define ncodeunits for ShowWith

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -156,6 +156,7 @@ function Base.show(io::IO, x::ShowWith; kw...)
 end
 Base.alignment(io::IO, x::ShowWith) =  alignment(io, x.val) .+ (2,0) # extra brackets
 Base.length(x::ShowWith) = length(string(x.val))
+Base.ncodeunits(x::ShowWith) = ncodeunits(string(x.val))
 Base.print(io::IO, x::ShowWith) = printstyled(io, string(x.val); x.nt...)
 
 # For higher-dim printing, I just want change the [:, :, 1] things, add name/key,


### PR DESCRIPTION
To fix #77.

`ShowWith` is an AbstractString, and from https://discourse.julialang.org/t/what-is-the-interface-of-abstractstring/8937/4 it seems that `ncodeunits` is a required method for it. But apparently this is only really needed from 1.7 onwards.

Does this look right? It seems to print alright, with unicode key names as well:

```julia
julia> using AxisKeys
julia> data = rand(Int8, 2,10,3) .|> abs;
julia> A = KeyedArray(data; channel=[:αααααααααααααααααα, :right], time=range(13, step=2.5, length=10), iter=31:33)
3-dimensional KeyedArray(NamedDimsArray(...)) with keys:
↓   channel ∈ 2-element Vector{Symbol}
→   time ∈ 10-element StepRangeLen{Float64,...}
□   iter ∈ 3-element UnitRange{Int64}
And data, 2×10×3 Array{Int8, 3}:
[:, :, 1] ~ (:, :, 31):
                         (13.0)  (15.5)  (18.0)  (20.5)  (23.0)  (25.5)  (28.0)  (30.5)  (33.0)  (35.5)
  (:αααααααααααααααααα)    88     127      28      99      40      43      72     125     106     107
  (:right)                  0      21      29      28       9       4      91     107       4      42

[:, :, 2] ~ (:, :, 32):
                         (13.0)  (15.5)  (18.0)  (20.5)  (23.0)  (25.5)  (28.0)  (30.5)  (33.0)  (35.5)
  (:αααααααααααααααααα)    56      53      88     123      82      42     104      79      47      64
  (:right)                 51       1     107     111      19     112      80     127      78     116

[:, :, 3] ~ (:, :, 33):
                         (13.0)  (15.5)  (18.0)  (20.5)  (23.0)  (25.5)  (28.0)  (30.5)  (33.0)  (35.5)
  (:αααααααααααααααααα)    24      57      57     108      73      19      54       8      33      22
  (:right)                 56      37      20      42      31      57      36      44      70     102
```