### PR TITLE
Minimal ArrayInterface.jl coupling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.19"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 CovarianceEstimation = "587fd27a-f159-11e8-2dae-1979310e6154"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
@@ -18,6 +19,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
+ArrayInterface = "3.1"
 BenchmarkTools = "0.5, 1.0"
 CovarianceEstimation = "0.2"
 IntervalSets = "0.5.1"

--- a/src/AxisKeys.jl
+++ b/src/AxisKeys.jl
@@ -32,4 +32,6 @@ include("fft.jl") # AbstractFFTs.jl
 
 include("statsbase.jl") # StatsBase.jl
 
+include("interface.jl") # ArrayInterface.jl
+
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,0 +1,7 @@
+# Minimal interface for LoopVectorization to work:
+# https://github.com/mcabbott/Tullio.jl/issues/125
+
+using ArrayInterface: ArrayInterface
+
+ArrayInterface.parent_type(::Type{<:KeyedArray{T,N,A}}) where {T,N,A} = A
+ArrayInterface.parent_type(::Type{<:NamedDimsArray{L,T,N,<:KeyedArray{T,N,A}}}) where {L,T,N,A} = A


### PR DESCRIPTION
Closes #84, xref https://github.com/mcabbott/Tullio.jl/issues/125#issuecomment-910773621

This adds a dependency with a few dependencies, and many more via Requires: 
https://juliahub.com/ui/Packages/ArrayInterface/7bROb/3.1.33?t=1

However, via a long path through various supposedly tiny packages, this package already depends on that, for now: https://github.com/JuliaMath/IntervalSets.jl/pull/57#issuecomment-919436500