### PR TITLE
Add ChainRule for `keyless_unname`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.23"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CovarianceEstimation = "587fd27a-f159-11e8-2dae-1979310e6154"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
@@ -19,7 +20,10 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 AbstractFFTs = "0.5, 1.0"
 BenchmarkTools = "0.5, 1.0"
+ChainRulesCore = "1"
+ChainRulesTestUtils = "1"
 CovarianceEstimation = "0.2"
+FiniteDifferences = "0.12"
 IntervalSets = "0.5.1"
 InvertedIndices = "1.0"
 LazyStack = "0.0.7, 0.0.8"
@@ -31,12 +35,14 @@ julia = "1"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 NamedArrays = "86f7a689-2022-50b4-a561-43c23ac3c673"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UniqueVectors = "2fbcfb34-fd0c-5fbb-b5d7-e826d8f5b0a9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["BenchmarkTools", "Dates", "FFTW", "NamedArrays", "Test", "UniqueVectors", "Unitful"]
+test = ["BenchmarkTools", "ChainRulesTestUtils", "Dates", "FiniteDifferences", "FFTW", "NamedArrays", "Test", "UniqueVectors", "Unitful"]

--- a/src/AxisKeys.jl
+++ b/src/AxisKeys.jl
@@ -32,4 +32,5 @@ include("fft.jl") # AbstractFFTs.jl
 
 include("statsbase.jl") # StatsBase.jl
 
+include("chainrules.jl")
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,11 +1,22 @@
 using ChainRulesCore
 
-_KeyedArray_pullback(ȳ::AbstractArray, keys) =  (NoTangent(), wrapdims(ȳ; keys...))
+_KeyedArray_pullback(ȳ::AbstractArray, keys) =  (NoTangent(), wrapdims(ȳ, keys...))
 _KeyedArray_pullback(ȳ::Tangent, keys) = _KeyedArray_pullback(ȳ.data, keys)
 _KeyedArray_pullback(ȳ::AbstractThunk, keys) = _KeyedArray_pullback(unthunk(ȳ), keys)
 
-function ChainRulesCore.rrule(::typeof(keyless_unname), x)
+function ChainRulesCore.rrule(::typeof(keyless_unname), x::KaNda)
     project_x = ProjectTo(x.data)
     pb(y) = _KeyedArray_pullback(project_x(y), named_axiskeys(x))
+    return keyless_unname(x), pb
+end
+
+function ChainRulesCore.rrule(::typeof(keyless_unname), x::KeyedArray)
+    project_x = ProjectTo(x.data)
+    pb(y) = _KeyedArray_pullback(project_x(y), axiskeys(x))
+    return keyless_unname(x), pb
+end
+
+function ChainRulesCore.rrule(::typeof(keyless_unname), x)
+    pb(y) = (NoTangent(), y)
     return keyless_unname(x), pb
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,0 +1,11 @@
+using ChainRulesCore
+
+_KeyedArray_pullback(ȳ::AbstractArray, keys) =  (NoTangent(), wrapdims(ȳ; keys...))
+_KeyedArray_pullback(ȳ::Tangent, keys) = _KeyedArray_pullback(ȳ.data, keys)
+_KeyedArray_pullback(ȳ::AbstractThunk, keys) = _KeyedArray_pullback(unthunk(ȳ), keys)
+
+function ChainRulesCore.rrule(::typeof(keyless_unname), x)
+    project_x = ProjectTo(x.data)
+    pb(y) = _KeyedArray_pullback(project_x(y), named_axiskeys(x))
+    return keyless_unname(x), pb
+end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -8,7 +8,7 @@ function ChainRulesCore.ProjectTo(x::KeyedArray)
     return ProjectTo{KeyedArray}(;data=ProjectTo(keyless(x)), keys=axiskeys(x))
 end
 
-(project::ProjectTo{KeyedArray})(dx) = wrapdims(project.data(dx), project.keys...)
+(project::ProjectTo{KeyedArray})(dx) = wrapdims(project.data(parent(dx)), project.keys...)
 
 _KeyedArray_pullback(ȳ, project) = (NoTangent(), project(ȳ))
 _KeyedArray_pullback(ȳ::Tangent, project) = _KeyedArray_pullback(ȳ.data, project)

--- a/test/_chainrules.jl
+++ b/test/_chainrules.jl
@@ -1,10 +1,20 @@
 @testset "chainrules.jl" begin
-    function FiniteDifferences.to_vec(k::KeyedArray)
+
+    function FiniteDifferences.to_vec(k::AxisKeys.KaNda)
         v, b = to_vec(k.data)
-        back(x) = KeyedArray(b(x); AxisKeys.named_axiskeys(k)...)
+        back(x) = wrapdims(b(x); AxisKeys.named_axiskeys(k)...)
         return v, back
     end
+
+    function FiniteDifferences.to_vec(k::KeyedArray)
+        v, b = to_vec(k.data)
+        back(x) = wrapdims(b(x), axiskeys(k)...)
+        return v, back
+    end
+
     test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), a=1:3); check_inferred=false)
     test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3, 4), a=1:3, b='a':'d'); check_inferred=false)
     test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), a=1:3); output_tangent=rand(3, 1), check_inferred=false)
+    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), 1:3); check_inferred=false)
+    test_rrule(AxisKeys.keyless_unname, ones(3); check_inferred=false)
 end

--- a/test/_chainrules.jl
+++ b/test/_chainrules.jl
@@ -12,9 +12,23 @@
         return v, back
     end
 
-    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), a=1:3); check_inferred=false)
-    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3, 4), a=1:3, b='a':'d'); check_inferred=false)
-    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), a=1:3); output_tangent=rand(3, 1), check_inferred=false)
-    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), 1:3); check_inferred=false)
-    test_rrule(AxisKeys.keyless_unname, ones(3); check_inferred=false)
+    @testset "KeyedVector" begin
+        data = rand(3)
+        test_rrule(AxisKeys.keyless_unname, wrapdims(data, a=1:3); check_inferred=false)
+        test_rrule(AxisKeys.keyless_unname, wrapdims(data, 1:3); check_inferred=false)
+        test_rrule(AxisKeys.keyless_unname, data; check_inferred=false)
+
+        # with matrix output tangent
+        test_rrule(AxisKeys.keyless_unname, wrapdims(data, a=1:3); output_tangent=rand(3, 1), check_inferred=false)
+        test_rrule(AxisKeys.keyless_unname, wrapdims(data, 1:3); output_tangent=rand(3, 1), check_inferred=false)
+        test_rrule(AxisKeys.keyless_unname, data; output_tangent=rand(3, 1), check_inferred=false)
+    end
+
+    @testset "KeyedMatrix" begin
+        data = rand(3, 4)
+        test_rrule(AxisKeys.keyless_unname, wrapdims(data, a=1:3, b='a':'d'); check_inferred=false)
+        test_rrule(AxisKeys.keyless_unname, wrapdims(data, 1:3, 'a':'d'); check_inferred=false)
+        test_rrule(AxisKeys.keyless_unname, data; check_inferred=false)
+    end
+
 end

--- a/test/_chainrules.jl
+++ b/test/_chainrules.jl
@@ -12,6 +12,18 @@
         return v, back
     end
 
+    @testset "ProjectTo" begin
+        data = rand(3)
+        ka = wrapdims(data, a=1:3)
+        p = ProjectTo(ka)
+        @test p(data) == ka
+
+        data = rand(3, 4)
+        ka = wrapdims(data, a=1:3, b='a':'d')
+        p = ProjectTo(ka)
+        @test p(data) == ka
+    end
+
     @testset "KeyedVector" begin
         data = rand(3)
         test_rrule(AxisKeys.keyless_unname, wrapdims(data, a=1:3); check_inferred=false)

--- a/test/_chainrules.jl
+++ b/test/_chainrules.jl
@@ -1,0 +1,10 @@
+@testset "chainrules.jl" begin
+    function FiniteDifferences.to_vec(k::KeyedArray)
+        v, b = to_vec(k.data)
+        back(x) = KeyedArray(b(x); AxisKeys.named_axiskeys(k)...)
+        return v, back
+    end
+    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), a=1:3); check_inferred=false)
+    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3, 4), a=1:3, b='a':'d'); check_inferred=false)
+    test_rrule(AxisKeys.keyless_unname, KeyedArray(ones(3), a=1:3); output_tangent=rand(3, 1), check_inferred=false)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test, AxisKeys, NamedDims
 using Statistics, OffsetArrays, Tables, UniqueVectors, LazyStack
+using ChainRulesCore: ProjectTo
 using ChainRulesTestUtils: test_rrule
 using FiniteDifferences
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test, AxisKeys, NamedDims
 using Statistics, OffsetArrays, Tables, UniqueVectors, LazyStack
+using ChainRulesTestUtils: test_rrule
+using FiniteDifferences
 
 @testset "wrapdims with $outside outside" for outside in [:NamedDimsArray, :KeyedArray]
 
@@ -16,6 +18,8 @@ using Statistics, OffsetArrays, Tables, UniqueVectors, LazyStack
     include("_fast.jl")
 
     include("_packages.jl")
+
+    include("_chainrules.jl")
 
 end
 @testset "fast findfirst & findall" begin


### PR DESCRIPTION
Essentially pair-programmed with @mzgubic.

Needed to add an `rrule` for `keyless_unname` for a downstream AD use-case.