### PR TITLE
support view of a single element by names/keys

### DIFF
--- a/src/names.jl
+++ b/src/names.jl
@@ -94,14 +94,14 @@ end
 
 @inline @propagate_inbounds (A::NdaKa)(args...) = getkey(A, args...)
 
-@inline @propagate_inbounds (A::KaNda)(;kw...) = getkey(A; kw...)
-@inline @propagate_inbounds (A::NdaKa)(;kw...) = getkey(A; kw...)
+@inline @propagate_inbounds (A::KaNda)(c=nothing; kw...) = getkey(A, c; kw...)
+@inline @propagate_inbounds (A::NdaKa)(c=nothing; kw...) = getkey(A, c; kw...)
 
-@inline @propagate_inbounds function getkey(A; kw...)
+@inline @propagate_inbounds function getkey(A, c::Union{Nothing, Colon}; kw...)
     list = dimnames(A)
     issubset(keys(kw), list) || error("some keywords not in list of names!")
     args = map(s -> Base.sym_in(s, keys(kw)) ? getfield(values(kw), s) : Colon(), list)
-    A(args...)
+    isnothing(c) ? A(args...) : A(args..., c)
 end
 
 # Constructors, including pirate method (A; kw...)

--- a/test/_basic.jl
+++ b/test/_basic.jl
@@ -170,6 +170,10 @@ end
 
         @test_throws Exception N(obs=55)  # ideally ArgumentError
         @test_throws Exception N(obs='z') # ideally BoundsError
+
+        Nc = copy(N)
+        Nc(obs='a', iter=20, :) .= 1000
+        @test Nc(obs='a', iter=20) == 1000
     end
 
     @testset "named_axiskeys" begin


### PR DESCRIPTION
As I understand, currently there is no way to set a single value specified by names and keys, as in `Nc(obs='a', iter=20, :) .= 1000`. This PR adds makes it possible.