### PR TITLE
Draft: Faster `wrapdims` over tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -144,7 +144,7 @@ function populate!(A, table, value::Symbol; force=false)
 
     # Ugly logic for reporting duplicates
     if !(force || allunique(indices))
-        seen = Dict{eltype(indices), nothing}()
+        seen = Dict{eltype(indices), Nothing}()
 
         for idx in indices
             if haskey(seen, idx)
@@ -158,7 +158,7 @@ function populate!(A, table, value::Symbol; force=false)
 
     A[indices] = Tables.getcolumn(cols, value)
 
-    return
+    return A
 end
 
 """


### PR DESCRIPTION
Rewrites `populate!` to operate columnwise over tables. Also, requires manually calling `findall` with the axiskeys and columns. With these changes the `wrapdims` call is ~5x faster and allocations 25% of the memory. 

Old:

```
julia> @benchmark wrapdims(df, :value, :time, :loc, :id)
BenchmarkTools.Trial: 163 samples with 1 evaluation.
 Range (min … max):  29.176 ms … 32.762 ms  ┊ GC (min … max): 0.00% … 8.68%
 Time  (median):     29.836 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   30.757 ms ±  1.356 ms  ┊ GC (mean ± σ):  3.87% ± 4.21%

    ▁▇▄▄█▃▆                                      ▇▁▃ ▄   ▁
  ▄▇██████████▁▆▁▁▃▃▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▄▃██████▇▆█▇▄▄ ▃
  29.2 ms         Histogram: frequency by time        32.7 ms <

 Memory estimate: 19.19 MiB, allocs estimate: 561688.
 ```

 New:
 ```
julia> @benchmark wrapdims(df, :value, :time, :loc, :id)
BenchmarkTools.Trial: 790 samples with 1 evaluation.
 Range (min … max):  6.067 ms …   7.721 ms  ┊ GC (min … max): 0.00% … 17.65%
 Time  (median):     6.171 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.326 ms ± 403.137 μs  ┊ GC (mean ± σ):  2.25% ±  5.30%

  ▁▃▆█▇▅▃▁   ▁                                       ▁▂
  █████████▇▇█▆▁▇▄▁▄▁▁▄▁▁▄▄▁▁▁▅▁▁▁▄▄▁▁▄▄▁▁▁▁▁▁▁▁▁▁▄▆█████▇▇▆▆ ▇
  6.07 ms      Histogram: log(frequency) by time      7.53 ms <

 Memory estimate: 5.15 MiB, allocs estimate: 4697.
 ```