### PR TITLE
Fix performance problem for `Tables.Columns(::KeyedArray)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -38,27 +38,11 @@ function Tables.columns(A::Union{KeyedArray, NdaKa})
     L = hasnames(A) ? (dimnames(A)..., :value) :
         (ntuple(d -> Symbol(:dim_,d), ndims(A))..., :value)
     R = keys_or_axes(A)
-    # R_inds = ntuple(d -> eachindex(R[i]), length(R))
     R_inds = map(eachindex, R)
-
-    # Add function barrier and dispatch on column number for local type stability.
-    _get_col(R, ::Val{d}) where {d} = vec([rs[d] for rs in Iterators.product(R...)])
-
-    inds = ntuple(identity, length(R))
     G = map(
         (r, d) -> vec([r[rs[d]] for rs in Iterators.product(R_inds...)]),
-        R, inds,
+        R, ntuple(identity, length(R)),
     )
-
-    # G = map(enumerate(R)) do (d, r)
-    #     @show d, typeof(r)
-    #     vec([r[rs[d]] for rs in Iterators.product(R_inds...)])
-    # end
-    # G = ntuple(ndims(A)) do d
-    #     # _get_col(R, Val(d))
-    #     vec([R[d][rs[d]] for rs in Iterators.product(R_inds...)])
-    #     # _vec(rs[d] for rs in Iterators.product(R...))
-    # end
     C = (G..., vec(parent(A)))
     NamedTuple{L}(C)
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -38,9 +38,18 @@ function Tables.columns(A::Union{KeyedArray, NdaKa})
     L = hasnames(A) ? (dimnames(A)..., :value) :
         (ntuple(d -> Symbol(:dim_,d), ndims(A))..., :value)
     R = keys_or_axes(A)
+
+    # R_inds comprises the indices for each of the keys.
+    
     R_inds = map(eachindex, R)
+    # indices is a tuple, the dth element of which is an index for the dth column of R.
+    # By using these indices, and mapping over the columns of R, the compiler seems to
+    # successfully infer the types in G, because it knows the element types of each column
+    # of R, so is presumably able to unroll the call to map.
+    # The previous implementation called `Iterators.product` on `R` and pulled out
+    # the dth element of `indices`, whose type it could not infer.
     G = map(
-        (r, d) -> vec([r[rs[d]] for rs in Iterators.product(R_inds...)]),
+        (r, d) -> vec([r[indices[d]] for indices in Iterators.product(R_inds...)]),
         R, ntuple(identity, length(R)),
     )
     C = (G..., vec(parent(A)))

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -37,7 +37,7 @@ Tables.columnaccess(::Type{<:KeyedArray{T,N,AT}}) where {T,N,AT} =
 function Tables.columns(A::Union{KeyedArray, NdaKa})
     L = hasnames(A) ? (dimnames(A)..., :value) :
         (ntuple(d -> Symbol(:dim_,d), ndims(A))..., :value)
-    G = _get_keys_columns(A)
+    G = _get_keys_columns(keys_or_axes(A))
     C = (G..., vec(parent(A)))
     NamedTuple{L}(C)
 end
@@ -48,8 +48,7 @@ end
 # of R, so is presumably able to unroll the call to map.
 # The previous implementation called `Iterators.product` on `R` and pulled out
 # the dth element of `indices`, whose type it could not infer.
-function _get_keys_columns(A)
-    R = keys_or_axes(A)
+function _get_keys_columns(R)
     R_inds = map(eachindex, R)
     return map(
         (r, d) -> vec([r[indices[d]] for indices in Iterators.product(R_inds...)]),

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -38,14 +38,27 @@ function Tables.columns(A::Union{KeyedArray, NdaKa})
     L = hasnames(A) ? (dimnames(A)..., :value) :
         (ntuple(d -> Symbol(:dim_,d), ndims(A))..., :value)
     R = keys_or_axes(A)
+    # R_inds = ntuple(d -> eachindex(R[i]), length(R))
+    R_inds = map(eachindex, R)
 
+    # Add function barrier and dispatch on column number for local type stability.
     _get_col(R, ::Val{d}) where {d} = vec([rs[d] for rs in Iterators.product(R...)])
 
-    G = ntuple(ndims(A)) do d
-        _get_col(R, Val(d))
-        # vec([rs[d] for rs in Iterators.product(R...)])
-        # _vec(rs[d] for rs in Iterators.product(R...))
-    end
+    inds = ntuple(identity, length(R))
+    G = map(
+        (r, d) -> vec([r[rs[d]] for rs in Iterators.product(R_inds...)]),
+        R, inds,
+    )
+
+    # G = map(enumerate(R)) do (d, r)
+    #     @show d, typeof(r)
+    #     vec([r[rs[d]] for rs in Iterators.product(R_inds...)])
+    # end
+    # G = ntuple(ndims(A)) do d
+    #     # _get_col(R, Val(d))
+    #     vec([R[d][rs[d]] for rs in Iterators.product(R_inds...)])
+    #     # _vec(rs[d] for rs in Iterators.product(R...))
+    # end
     C = (G..., vec(parent(A)))
     NamedTuple{L}(C)
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -38,8 +38,12 @@ function Tables.columns(A::Union{KeyedArray, NdaKa})
     L = hasnames(A) ? (dimnames(A)..., :value) :
         (ntuple(d -> Symbol(:dim_,d), ndims(A))..., :value)
     R = keys_or_axes(A)
+
+    _get_col(R, ::Val{d}) where {d} = vec([rs[d] for rs in Iterators.product(R...)])
+
     G = ntuple(ndims(A)) do d
-        vec([rs[d] for rs in Iterators.product(R...)])
+        _get_col(R, Val(d))
+        # vec([rs[d] for rs in Iterators.product(R...)])
         # _vec(rs[d] for rs in Iterators.product(R...))
     end
     C = (G..., vec(parent(A)))

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -50,10 +50,9 @@ end
 # the dth element of `indices`, whose type it could not infer.
 function _get_keys_columns(R)
     R_inds = map(eachindex, R)
-    return map(
-        (r, d) -> vec([r[indices[d]] for indices in Iterators.product(R_inds...)]),
-        R, ntuple(identity, length(R)),
-    )
+    return map(R, ntuple(identity, length(R))) do r, d
+        vec([r[indices[d]] for indices in Iterators.product(R_inds...)])
+    end
 end
 
 function Tables.Schema(nt::NamedTuple) # 🏴‍☠️

--- a/test/_packages.jl
+++ b/test/_packages.jl
@@ -49,6 +49,15 @@ end
         @test keys(first(Tables.rows(N))) == (:a, :b, :value)
 
         @test Tables.columns(N).a == [11, 12, 11, 12, 11, 12]
+
+        # Regression test: https://github.com/mcabbott/AxisKeys.jl/pull/123
+        @testset "Tables.columns(::AxisKeys) type stability" begin
+            a = randn(5)
+            b = randn(Float32, 4)
+            @inferred AxisKeys._get_keys_columns((a, b))
+            X = wrapdims(randn(5, 4); a, b)
+            @inferred Tables.columns(X)
+        end
     end
     @testset "sink" begin
         A = KeyedArray(rand(24, 11, 3); time = 0:23, loc = -5:5, id = ["a", "b", "c"])


### PR DESCRIPTION
There's a type stability issue which occurs in `Tables.columns` when the type of the keys are different on different axes.

I demonstrate that the problem exists, and that this PR fixes it. Not sure what kind of regression test would be optimal, but happy to add one / some if there's an obvious place to put them.


# MWE
```julia
using AxisKeys, Tables

D1 = 2500;
D2 = 2500;
data = randn(D1, D2);
k1 = collect(1:D1);

# Choose between these two to swap between having the same and different key types.
k2 = Int32.(collect(1:D2));
# k2 = collect(1:D2);

X = KeyedArray(data; k1, k2);
@benchmark Tables.columns($X)
```
on master then output of benchmarking is
```julia
BenchmarkTools.Trial: 8 samples with 1 evaluation.
 Range (min … max):  654.951 ms … 766.341 ms  ┊ GC (min … max):  8.84% … 17.49%
 Time  (median):     696.806 ms               ┊ GC (median):    12.74%
 Time  (mean ± σ):   704.700 ms ±  42.018 ms  ┊ GC (mean ± σ):  13.40% ±  4.94%

  █             ▁      ▁  ▁                    ▁     ▁        ▁  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁█▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁█▁▁▁▁▁▁▁▁█ ▁
  655 ms           Histogram: frequency by time          766 ms <

 Memory estimate: 604.74 MiB, allocs estimate: 22445012.
```

On this branch it's
```julia
BenchmarkTools.Trial: 252 samples with 1 evaluation.
 Range (min … max):  18.942 ms … 24.603 ms  ┊ GC (min … max): 0.00% … 21.99%
 Time  (median):     19.035 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   19.889 ms ±  1.933 ms  ┊ GC (mean ± σ):  4.34% ±  7.99%

  █▇                                                        ▂  
  ███▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▁▁▇█▄▇██ ▅
  18.9 ms      Histogram: log(frequency) by time      24.4 ms <

 Memory estimate: 71.53 MiB, allocs estimate: 10.
```
By changing the value of `k2` to comprise `Int64`s, you can verify that this doesn't cause a performance regression for the situation in which the keys are the same type, in which case there isn't presently a type-instability.



