### PR TITLE
Replace `_maybetail` with `safe_tail`

### DIFF
--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -208,8 +208,8 @@ end
 @inline Base.to_indices(A::Union{KeyedArray,NdaKa}, ax, inds::Tuple{Function, Vararg}) =
     select_to_indices(A, ax, inds)
 
-using Base: to_indices, tail, _maybetail, uncolon
+using Base: to_indices, tail, safe_tail, uncolon
 
 @inline Base.to_indices(A::Union{KeyedArray,NdaKa}, inds, I::Tuple{Colon, Vararg{Any}}) =
-    (uncolon(inds, I), to_indices(A, _maybetail(inds), tail(I))...)
+    (uncolon(inds, I), to_indices(A, safe_tail(inds), tail(I))...)
 


### PR DESCRIPTION
This was motivated by the disappearance of `_maybetail` from `Base`,
which causes `AxisKeys` to not be compatible with v1.9. As it happens,
`safe_tail` is identical to `_maybetail`, thus, it would seem that the
latter was eliminated due to redundancy. Inspection of the v1.6
branch of JuliaLang confirms that `safe_tail` exists in its same form,
thus, given the `[compat]` for this `AxisKeys`, this seems like a
harmless change which enables compatibility with `master`.