### PR TITLE
Fix #128 broadcast ambiguities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -42,7 +42,7 @@ end
 
 function unwrap_broadcasted(bc::Broadcasted{KeyedStyle{S}}) where {S}
     inner_args = map(unwrap_broadcasted, bc.args)
-    Broadcasted{S}(bc.f, inner_args)
+    Broadcasted{S}(bc.f, inner_args, axes(bc))
 end
 unwrap_broadcasted(x) = x
 unwrap_broadcasted(x::KeyedArray) = parent(x)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -21,13 +21,24 @@ Base.BroadcastStyle(::Type{<:KeyedArray{T,N,AT}}) where {T,N,AT} =
 Base.BroadcastStyle(::KeyedStyle{A}, ::KeyedStyle{B}) where {A, B} = KeyedStyle(A(), B())
 Base.BroadcastStyle(::KeyedStyle{A}, b::B) where {A, B} = KeyedStyle(A(), b)
 Base.BroadcastStyle(a::A, ::KeyedStyle{B}) where {A, B} = KeyedStyle(a, B())
-Base.BroadcastStyle(::KeyedStyle{A}, b::DefaultArrayStyle) where {A} = KeyedStyle(A(), b)
-Base.BroadcastStyle(a::AbstractArrayStyle{M}, ::KeyedStyle{B}) where {B,M} = KeyedStyle(a, B())
 
 using NamedDims: NamedDimsStyle
 # this resolves in favour of KeyedArray(NamedDimsArray())
 Base.BroadcastStyle(a::NamedDimsStyle, ::KeyedStyle{B}) where {B} = KeyedStyle(a, B())
 Base.BroadcastStyle(::KeyedStyle{A}, b::NamedDimsStyle) where {A} = KeyedStyle(A(), b)
+
+# Resolve ambiguities
+# for all these cases, we define that we win to be the outer style regardless of order
+for B in (
+    :BroadcastStyle, :DefaultArrayStyle, :AbstractArrayStyle, :(Broadcast.Style{Tuple}),
+)
+    @eval function Base.BroadcastStyle(::KeyedStyle{A}, b::$B) where A
+        return KeyedStyle(A(), b)
+    end
+    @eval function Base.BroadcastStyle(b::$B, ::KeyedStyle{A}) where A
+        return KeyedStyle(b, A())
+    end
+end
 
 function unwrap_broadcasted(bc::Broadcasted{KeyedStyle{S}}) where {S}
     inner_args = map(unwrap_broadcasted, bc.args)

--- a/test/_basic.jl
+++ b/test/_basic.jl
@@ -259,6 +259,17 @@ end
         @test_throws Exception unify_keys((1:2,), ([3,4],))
 
     end
+    @testset "https://github.com/mcabbott/AxisKeys.jl/issues/128" begin
+        using LinearAlgebra
+
+        # Really simple test that broadcasting with linalg array types works.
+        v = rand(10)
+        σ = wrapdims(v; time=-4:5)
+        L = LowerTriangular(reshape(1.0:1.0:100, (10, 10)))
+        σ .* L
+        v .* L
+        @test σ .* L ≈ v .* L
+    end
 end
 @testset "bitarray" begin
 


### PR DESCRIPTION
Closes #128 

This is the same thing we're doing in NamedDims.jl here 

https://github.com/invenia/NamedDims.jl/blob/master/src/broadcasting.jl#L30

Working example output:

```
julia> using Revise, AxisKeys, LinearAlgebra
[ Info: Precompiling AxisKeys [94b1ba4f-4ee9-5380-92f1-94cde586c3c5]

julia> σ = wrapdims(rand(10); time=-5:5)
┌ Warning: range -5:5 replaced by -5:4, to match size(A, 1) == 10
└ @ AxisKeys ~/repos/invenia/AxisKeys.jl/src/wrap.jl:72
1-dimensional KeyedArray(NamedDimsArray(...)) with keys:
↓   time ∈ 10-element UnitRange{Int64}
And data, 10-element Vector{Float64}:
 (-5)  0.7062162964371984
 (-4)  0.7932003097802828
 (-3)  0.3350060730546587
 (-2)  0.9305918994338884
 (-1)  0.4487008300540162
  (0)  0.2893126114180271
  (1)  0.22276748390348022
  (2)  0.8940313473571855
  (3)  0.4626404422715904
  (4)  0.7241747707977281

julia> L = LowerTriangular(reshape(1.0:1.0:100, (10, 10)))
10×10 LowerTriangular{Float64, Base.ReshapedArray{Float64, 2, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}, Tuple{}}}:
  1.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅      ⋅
  2.0  12.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅      ⋅
  3.0  13.0  23.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅      ⋅
  4.0  14.0  24.0  34.0    ⋅     ⋅     ⋅     ⋅     ⋅      ⋅
  5.0  15.0  25.0  35.0  45.0    ⋅     ⋅     ⋅     ⋅      ⋅
  6.0  16.0  26.0  36.0  46.0  56.0    ⋅     ⋅     ⋅      ⋅
  7.0  17.0  27.0  37.0  47.0  57.0  67.0    ⋅     ⋅      ⋅
  8.0  18.0  28.0  38.0  48.0  58.0  68.0  78.0    ⋅      ⋅
  9.0  19.0  29.0  39.0  49.0  59.0  69.0  79.0  89.0     ⋅
 10.0  20.0  30.0  40.0  50.0  60.0  70.0  80.0  90.0  100.0

julia> σ .* L
2-dimensional KeyedArray(NamedDimsArray(...)) with keys:
↓   time ∈ 10-element UnitRange{Int64}
→   _ ∈ 10-element OneTo{Int}
And data, 10×10 Matrix{Float64}:
       (1)         (2)        (3)        (4)       (5)       (6)       (7)       (8)       (9)       (10)
 (-5)    0.706216    0.0        0.0        0.0       0.0       0.0       0.0       0.0       0.0        0.0
 (-4)    1.5864      9.5184     0.0        0.0       0.0       0.0       0.0       0.0       0.0        0.0
 (-3)    1.00502     4.35508    7.70514    0.0       0.0       0.0       0.0       0.0       0.0        0.0
 (-2)    3.72237    13.0283    22.3342    31.6401    0.0       0.0       0.0       0.0       0.0        0.0
 (-1)    2.2435      6.73051   11.2175    15.7045   20.1915    0.0       0.0       0.0       0.0        0.0
  (0)    1.73588     4.629      7.52213   10.4153   13.3084   16.2015    0.0       0.0       0.0        0.0
  (1)    1.55937     3.78705    6.01472    8.2424   10.4701   12.6977   14.9254    0.0       0.0        0.0
  (2)    7.15225    16.0926    25.0329    33.9732   42.9135   51.8538   60.7941   69.7344    0.0        0.0
  (3)    4.16376     8.79017   13.4166    18.043    22.6694   27.2958   31.9222   36.5486   41.175      0.0
  (4)    7.24175    14.4835    21.7252    28.967    36.2087   43.4505   50.6922   57.934    65.1757    72.4175
```