### PR TITLE
remove deprecated `VarArg{<:...}`

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -14,11 +14,11 @@ function LazyStack.rewrap_like(A, a::NamedTuple)
 end
 
 # tuple of arrays
-function LazyStack.stack(x::Tuple{Vararg{<:KeyedArray}})
+function LazyStack.stack(x::Tuple{Vararg{KeyedArray}})
     KeyedArray(LazyStack.stack(map(parent, x)), stack_keys(x))
 end
 
-stack_keys(xs::Tuple{Vararg{<:KeyedArray}}) =
+stack_keys(xs::Tuple{Vararg{KeyedArray}}) =
     (keys_or_axes(first(xs))..., Base.OneTo(length(xs)))
 
 # array of arrays: first strip off outer containers...

--- a/src/statsbase.jl
+++ b/src/statsbase.jl
@@ -48,7 +48,7 @@ end
 
 for fun in (:std, :var, :cov)
     full_name = Symbol("mean_and_$fun")
-    @eval StatsBase.$full_name(A::KeyedMatrix, wv::Vararg{<:AbstractWeights}; dims=:, corrected::Bool=true, kwargs...) =
+    @eval StatsBase.$full_name(A::KeyedMatrix, wv::Vararg{AbstractWeights}; dims=:, corrected::Bool=true, kwargs...) =
         (
             mean(A, wv...; dims=dims, kwargs...),
             $fun(A, wv...; dims=dims, corrected=corrected, kwargs...)


### PR DESCRIPTION
no functional change.