### PR TITLE
Add method `Base.emtpy!(::KeyedVector)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -441,4 +441,9 @@ function Base.filter!(f, a::KeyedVector)
     deleteat!(a, j:lastindex(a))
     return a
 end
-                                                                
+
+function Base.empty!(v::KeyedVector)
+    empty!(axiskeys(v, 1))
+    empty!(v.data)
+    return v
+end

--- a/test/_functions.jl
+++ b/test/_functions.jl
@@ -148,7 +148,7 @@ end
 
     @test axiskeys(filter(isodd, V2),1) isa Vector{Int}
     @test dimnames(filter(isodd, V2)) == (:v,)
-    
+
     V4 = wrapdims(rand(1:99, 10), collect(2:11))
     V4c = copy(V4)
     @test filter!(isodd, V4c) === V4c == filter(isodd, V4)
@@ -285,6 +285,17 @@ end
     # make sure array is not in an invalid state if the deleteat for indices fails
     ka = wrapdims([4, 5, 6.0], a=1:3)
     @test_throws MethodError deleteat!(ka, 2)
+    @test ka == KeyedArray([4, 5, 6.0], a=1:3)
+end
+
+@testset "empty!" begin
+    kv = wrapdims([1, 2, 3, 4, 5, 6.0], a=[:a, :b, :c, :d, :e, :f])
+    @test kv == empty!(kv)
+    @test isempty(kv)
+
+    # make sure array is not in an invalid state if the emtpy for indices fails
+    ka = wrapdims([4, 5, 6.0], a=1:3)
+    @test_throws MethodError empty!(ka)
     @test ka == KeyedArray([4, 5, 6.0], a=1:3)
 end
 


### PR DESCRIPTION
Closes https://github.com/mcabbott/AxisKeys.jl/issues/136

`Base.empty!` does not seem to be defined on general `Array`s, so this PR only extends the method  for keyed vectors.