### PR TITLE
Add support for StatsBase 0.34

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.12"
+version = "0.2.13"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -30,7 +30,7 @@ InvertedIndices = "1.0"
 LazyStack = "0.0.7, 0.0.8"
 NamedDims = "0.2.46, 0.3, 1"
 OffsetArrays = "0.10, 0.11, 1.0"
-StatsBase = "0.32, 0.33"
+StatsBase = "0.32, 0.33, 0.34"
 Tables = "0.2, 1"
 julia = "1.6"
 


### PR DESCRIPTION
Not sure if tests pass but as the breaking change was minimal IIRC (weighted sampling errors now if any weight is `NaN`) I think chances are high they will.

On a side note, this update went unnoticed since the CompatHelper action fails.