### PR TITLE
fix inplace sort! on Julia 1.9 with non int eltypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.14"
+version = "0.2.15"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -239,7 +239,11 @@ function Base.sort(A::KeyedVector; kw...)
 end
 
 function Base.sort!(A::KeyedVector; kw...)
-    perm = sortperm(parent(A); kw...)
+    @static if VERSION >= v"1.9"
+        perm = sortperm(parent(A); kw..., scratch=Vector{Int}(undef, length(A)))
+    else
+        perm = sortperm(parent(A); kw...)
+    end
     permute!(axiskeys(A,1), perm) # error if keys cannot be sorted, could treat like push!
     permute!(parent(A), perm)
     A

--- a/test/_functions.jl
+++ b/test/_functions.jl
@@ -4,6 +4,7 @@ using NamedDims: unname
 M = wrapdims(rand(Int8, 3,4), r='a':'c', c=2:5)
 MN = NamedDimsArray(M.data.data, r='a':'c', c=2:5)
 V = wrapdims(rand(1:99, 10), v=10:10:100)
+
 VN = NamedDimsArray(V.data.data, v=10:10:100)
 A3 = wrapdims(rand(Int8, 3,4,2), r='a':'c', c=2:5, p=[10.0, 20.0])
 
@@ -87,6 +88,9 @@ end
 @testset "sort & reverse" begin
 
     @test sort(V)(20) == V(20)
+    # need to test with non integer eltypes:
+    @test sort!(float.(V))(20) == V(20)
+    @test first(sort!(float.(A3); dims=1)) == first(sort(A3; dims=1))
 
     @test axiskeys(sort(M, dims=:c), :c) isa Base.OneTo
     @test axiskeys(sort(M, dims=:c), :r) == 'a':'c'

--- a/test/_functions.jl
+++ b/test/_functions.jl
@@ -4,9 +4,14 @@ using NamedDims: unname
 M = wrapdims(rand(Int8, 3,4), r='a':'c', c=2:5)
 MN = NamedDimsArray(M.data.data, r='a':'c', c=2:5)
 V = wrapdims(rand(1:99, 10), v=10:10:100)
+# used for an inplace sort! later, so axiskeys need to be a container
+# that supports setindex!
+VF = wrapdims(rand(10), v=collect(10:10:100))
 
 VN = NamedDimsArray(V.data.data, v=10:10:100)
-A3 = wrapdims(rand(Int8, 3,4,2), r='a':'c', c=2:5, p=[10.0, 20.0])
+# used for an inplace sort! later, so axiskeys need to be a container
+# that supports setindex!
+A3 = wrapdims(rand(Int8, 3,4,2), r=collect('a':'c'), c=collect(2:5), p=[10.0, 20.0])
 
 @testset "dims" begin
 
@@ -89,7 +94,7 @@ end
 
     @test sort(V)(20) == V(20)
     # need to test with non integer eltypes:
-    @test sort!(float.(V))(20) == V(20)
+    @test sort!(deepcopy(VF))(20) == VF(20)
     @test first(sort!(float.(A3); dims=1)) == first(sort(A3; dims=1))
 
     @test axiskeys(sort(M, dims=:c), :c) isa Base.OneTo


### PR DESCRIPTION
As noted in https://github.com/JuliaLang/julia/issues/53113#issuecomment-1917753732, this still relies on an implementation detail for multi-dimensional array sorting, but explicitly passing the `scratch` kwarg addresses the immediate problem.